### PR TITLE
[18.0] [MIG] shopinvader_search_engine_product_price

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,6 @@ exclude: |
   ^shopinvader_search_engine_product_brand_image/|
   ^shopinvader_search_engine_product_media/|
   ^shopinvader_search_engine_product_multi_price/|
-  ^shopinvader_search_engine_product_price/|
   ^shopinvader_search_engine_product_seo/|
   ^shopinvader_search_engine_product_stock/|
   ^shopinvader_search_engine_product_stock_state/|

--- a/shopinvader_search_engine_product_price/README.rst
+++ b/shopinvader_search_engine_product_price/README.rst
@@ -16,14 +16,14 @@ Shopinvader Search Engine Product Price
 .. |badge2| image:: https://img.shields.io/badge/licence-AGPL--3-blue.png
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
-.. |badge3| image:: https://img.shields.io/badge/github-shopinvader%2Fodoo--shopinvader-lightgray.png?logo=github
-    :target: https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_search_engine_product_price
-    :alt: shopinvader/odoo-shopinvader
+.. |badge3| image:: https://img.shields.io/badge/github-shopinvader%2Fodoo--shopinvader--search--engine-lightgray.png?logo=github
+    :target: https://github.com/shopinvader/odoo-shopinvader-search-engine/tree/18.0/shopinvader_search_engine_product_price
+    :alt: shopinvader/odoo-shopinvader-search-engine
 
 |badge1| |badge2| |badge3|
 
-Adds prices to the export of products for Shopinvader.
-For advanced use cases, this addon can be substituted by other price calculation addons.
+Adds prices to the export of products for Shopinvader. For advanced use
+cases, this addon can be substituted by other price calculation addons.
 
 .. IMPORTANT::
    This is an alpha version, the data model and design can change at any time without warning.
@@ -38,15 +38,16 @@ For advanced use cases, this addon can be substituted by other price calculation
 Usage
 =====
 
-Set pricelist per index or on the search engine backend to apply gloabally.
+Set pricelist per index or on the search engine backend to apply
+gloabally.
 
 Bug Tracker
 ===========
 
-Bugs are tracked on `GitHub Issues <https://github.com/shopinvader/odoo-shopinvader/issues>`_.
+Bugs are tracked on `GitHub Issues <https://github.com/shopinvader/odoo-shopinvader-search-engine/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/shopinvader/odoo-shopinvader/issues/new?body=module:%20shopinvader_search_engine_product_price%0Aversion:%2016.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/shopinvader/odoo-shopinvader-search-engine/issues/new?body=module:%20shopinvader_search_engine_product_price%0Aversion:%2018.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -54,18 +55,18 @@ Credits
 =======
 
 Authors
-~~~~~~~
+-------
 
 * ACSONE SA/NV
 
 Contributors
-~~~~~~~~~~~~
+------------
 
-* Quentin Groulard <quentin.groulard@acsone.eu>
+- Quentin Groulard <quentin.groulard@acsone.eu>
 
 Maintainers
-~~~~~~~~~~~
+-----------
 
-This module is part of the `shopinvader/odoo-shopinvader <https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_search_engine_product_price>`_ project on GitHub.
+This module is part of the `shopinvader/odoo-shopinvader-search-engine <https://github.com/shopinvader/odoo-shopinvader-search-engine/tree/18.0/shopinvader_search_engine_product_price>`_ project on GitHub.
 
 You are welcome to contribute.

--- a/shopinvader_search_engine_product_price/__manifest__.py
+++ b/shopinvader_search_engine_product_price/__manifest__.py
@@ -3,16 +3,14 @@
 
 {
     "name": "Shopinvader Search Engine Product Price",
-    "summary": """
-        Add the export of product prices for Shopinvader""",
-    "version": "16.0.1.1.0",
+    "summary": "Add the export of product prices for Shopinvader",
+    "version": "18.0.1.0.0",
     "category": "e-commerce",
     "license": "AGPL-3",
     "author": "ACSONE SA/NV",
     "website": "https://github.com/shopinvader/odoo-shopinvader-search-engine",
     "depends": ["product_get_price_helper", "shopinvader_search_engine"],
     "data": ["views/se_backend.xml", "views/se_index.xml"],
-    "demo": [],
-    "installable": False,
+    "installable": True,
     "development_status": "Alpha",
 }

--- a/shopinvader_search_engine_product_price/models/product_product.py
+++ b/shopinvader_search_engine_product_price/models/product_product.py
@@ -16,6 +16,6 @@ class ProductProduct(models.Model):
         pricelist = None
         if index_id:
             pricelist = index._get_pricelist()
-        price_unit_list = self._get_price(pricelist=pricelist)
+
         for record in self:
-            record.shopinvader_price = price_unit_list[record.id]
+            record.shopinvader_price = record._get_price(pricelist=pricelist)

--- a/shopinvader_search_engine_product_price/models/se_backend.py
+++ b/shopinvader_search_engine_product_price/models/se_backend.py
@@ -1,18 +1,13 @@
 # Copyright 2023 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class SeBackend(models.Model):
     _inherit = "se.backend"
 
-    @api.model
-    def _default_pricelist_id(self):
-        return self.env.ref("product.list0")
-
     pricelist_id = fields.Many2one(
         "product.pricelist",
         string="Pricelist",
-        default=lambda self: self._default_pricelist_id(),
     )

--- a/shopinvader_search_engine_product_price/pyproject.toml
+++ b/shopinvader_search_engine_product_price/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/shopinvader_search_engine_product_price/readme/CONTRIBUTORS.md
+++ b/shopinvader_search_engine_product_price/readme/CONTRIBUTORS.md
@@ -1,0 +1,1 @@
+- Quentin Groulard \<quentin.groulard@acsone.eu\>

--- a/shopinvader_search_engine_product_price/readme/CONTRIBUTORS.rst
+++ b/shopinvader_search_engine_product_price/readme/CONTRIBUTORS.rst
@@ -1,1 +1,0 @@
-* Quentin Groulard <quentin.groulard@acsone.eu>

--- a/shopinvader_search_engine_product_price/readme/DESCRIPTION.md
+++ b/shopinvader_search_engine_product_price/readme/DESCRIPTION.md
@@ -1,0 +1,2 @@
+Adds prices to the export of products for Shopinvader. For advanced use
+cases, this addon can be substituted by other price calculation addons.

--- a/shopinvader_search_engine_product_price/readme/DESCRIPTION.rst
+++ b/shopinvader_search_engine_product_price/readme/DESCRIPTION.rst
@@ -1,2 +1,0 @@
-Adds prices to the export of products for Shopinvader.
-For advanced use cases, this addon can be substituted by other price calculation addons.

--- a/shopinvader_search_engine_product_price/readme/USAGE.md
+++ b/shopinvader_search_engine_product_price/readme/USAGE.md
@@ -1,0 +1,2 @@
+Set pricelist per index or on the search engine backend to apply
+gloabally.

--- a/shopinvader_search_engine_product_price/readme/USAGE.rst
+++ b/shopinvader_search_engine_product_price/readme/USAGE.rst
@@ -1,1 +1,0 @@
-Set pricelist per index or on the search engine backend to apply gloabally.

--- a/shopinvader_search_engine_product_price/static/description/index.html
+++ b/shopinvader_search_engine_product_price/static/description/index.html
@@ -369,9 +369,9 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:d7a930fe3450d1c047c2c51a9ddae06ef839551f2e5e1de4e900680fba4b6a81
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Alpha" src="https://img.shields.io/badge/maturity-Alpha-red.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_search_engine_product_price"><img alt="shopinvader/odoo-shopinvader" src="https://img.shields.io/badge/github-shopinvader%2Fodoo--shopinvader-lightgray.png?logo=github" /></a></p>
-<p>Adds prices to the export of products for Shopinvader.
-For advanced use cases, this addon can be substituted by other price calculation addons.</p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Alpha" src="https://img.shields.io/badge/maturity-Alpha-red.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/shopinvader/odoo-shopinvader-search-engine/tree/18.0/shopinvader_search_engine_product_price"><img alt="shopinvader/odoo-shopinvader-search-engine" src="https://img.shields.io/badge/github-shopinvader%2Fodoo--shopinvader--search--engine-lightgray.png?logo=github" /></a></p>
+<p>Adds prices to the export of products for Shopinvader. For advanced use
+cases, this addon can be substituted by other price calculation addons.</p>
 <div class="admonition important">
 <p class="first admonition-title">Important</p>
 <p class="last">This is an alpha version, the data model and design can change at any time without warning.
@@ -393,14 +393,15 @@ Only for development or testing purpose, do not use in production.
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
-<p>Set pricelist per index or on the search engine backend to apply gloabally.</p>
+<p>Set pricelist per index or on the search engine backend to apply
+gloabally.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
-<p>Bugs are tracked on <a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader/issues">GitHub Issues</a>.
+<p>Bugs are tracked on <a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader-search-engine/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader/issues/new?body=module:%20shopinvader_search_engine_product_price%0Aversion:%2016.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader-search-engine/issues/new?body=module:%20shopinvader_search_engine_product_price%0Aversion:%2018.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
@@ -419,7 +420,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
-<p>This module is part of the <a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_search_engine_product_price">shopinvader/odoo-shopinvader</a> project on GitHub.</p>
+<p>This module is part of the <a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader-search-engine/tree/18.0/shopinvader_search_engine_product_price">shopinvader/odoo-shopinvader-search-engine</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>
 </div>

--- a/shopinvader_search_engine_product_price/tests/test_product_binding.py
+++ b/shopinvader_search_engine_product_price/tests/test_product_binding.py
@@ -5,19 +5,19 @@ from odoo.addons.shopinvader_search_engine.tests.common import TestBindingIndexB
 
 
 class TestProductBinding(TestBindingIndexBase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.index = cls.env["se.index"].create(
+    def setup_records(self, backend=None):
+        rv = super().setup_records(backend=backend)
+        self.index = self.env["se.index"].create(
             {
                 "name": "product",
-                "backend_id": cls.backend.id,
-                "model_id": cls.env.ref("product.model_product_product").id,
+                "backend_id": self.backend.id,
+                "model_id": self.env.ref("product.model_product_product").id,
                 "serializer_type": "shopinvader_product_exports",
             }
         )
-        cls.product = cls.env.ref("product.product_product_4b")
-        cls.product_binding = cls.product._add_to_index(cls.index)
+        self.product = self.env.ref("product.product_product_4b")
+        self.product_binding = self.product._add_to_index(self.index)
+        return rv
 
     def test_binding_price(self):
         self.product_binding.recompute_json()


### PR DESCRIPTION
Standard migration

Depends on: 
  - https://github.com/OCA/search-engine/pull/222
  - https://github.com/OCA/search-engine/pull/224
  - https://github.com/OCA/product-attribute/pull/2130
  - https://github.com/shopinvader/odoo-shopinvader-catalog/pull/2
  - #2

Might be nice to forward port  https://github.com/OCA/product-attribute/pull/1954/changes/615ee219991615063bd3c62e3f73d9d4116135ef