### PR TITLE
[18.0] [MIG] shopinvader_search_engine_product_multi_price

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,6 @@ exclude: |
   ^shopinvader_search_engine_product_brand/|
   ^shopinvader_search_engine_product_brand_image/|
   ^shopinvader_search_engine_product_media/|
-  ^shopinvader_search_engine_product_multi_price/|
   ^shopinvader_search_engine_product_seo/|
   ^shopinvader_search_engine_product_stock_state/|
   ^shopinvader_search_engine_product_template_multi_link/|

--- a/shopinvader_search_engine_product_multi_price/README.rst
+++ b/shopinvader_search_engine_product_multi_price/README.rst
@@ -16,18 +16,19 @@ Shopinvader Search Engine Product Multi Price
 .. |badge2| image:: https://img.shields.io/badge/licence-AGPL--3-blue.png
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
-.. |badge3| image:: https://img.shields.io/badge/github-shopinvader%2Fodoo--shopinvader-lightgray.png?logo=github
-    :target: https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_search_engine_product_multi_price
-    :alt: shopinvader/odoo-shopinvader
+.. |badge3| image:: https://img.shields.io/badge/github-shopinvader%2Fodoo--shopinvader--search--engine-lightgray.png?logo=github
+    :target: https://github.com/shopinvader/odoo-shopinvader-search-engine/tree/18.0/shopinvader_search_engine_product_multi_price
+    :alt: shopinvader/odoo-shopinvader-search-engine
 
 |badge1| |badge2| |badge3|
 
-Adds prices to the export of products for Shopinvader.
-One price is exported per pricelist set on the index.
+Adds prices to the export of products for Shopinvader. One price is
+exported per pricelist set on the index.
 
 It means that your website needs to know which pricelist to choose.
-Thus, we suggest to use this module in combination with ``shopinvader_api_customer``,
-which provides an API to get the customer's pricelist.
+Thus, we suggest to use this module in combination with
+``shopinvader_api_customer``, which provides an API to get the
+customer's pricelist.
 
 .. IMPORTANT::
    This is an alpha version, the data model and design can change at any time without warning.
@@ -42,15 +43,16 @@ which provides an API to get the customer's pricelist.
 Usage
 =====
 
-Set pricelists per index or on the search engine backend to apply globally.
+Set pricelists per index or on the search engine backend to apply
+globally.
 
 Bug Tracker
 ===========
 
-Bugs are tracked on `GitHub Issues <https://github.com/shopinvader/odoo-shopinvader/issues>`_.
+Bugs are tracked on `GitHub Issues <https://github.com/shopinvader/odoo-shopinvader-search-engine/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/shopinvader/odoo-shopinvader/issues/new?body=module:%20shopinvader_search_engine_product_multi_price%0Aversion:%2016.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/shopinvader/odoo-shopinvader-search-engine/issues/new?body=module:%20shopinvader_search_engine_product_multi_price%0Aversion:%2018.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -58,18 +60,18 @@ Credits
 =======
 
 Authors
-~~~~~~~
+-------
 
 * ACSONE SA/NV
 
 Contributors
-~~~~~~~~~~~~
+------------
 
-* Quentin Groulard <quentin.groulard@acsone.eu>
+- Quentin Groulard <quentin.groulard@acsone.eu>
 
 Maintainers
-~~~~~~~~~~~
+-----------
 
-This module is part of the `shopinvader/odoo-shopinvader <https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_search_engine_product_multi_price>`_ project on GitHub.
+This module is part of the `shopinvader/odoo-shopinvader-search-engine <https://github.com/shopinvader/odoo-shopinvader-search-engine/tree/18.0/shopinvader_search_engine_product_multi_price>`_ project on GitHub.
 
 You are welcome to contribute.

--- a/shopinvader_search_engine_product_multi_price/__manifest__.py
+++ b/shopinvader_search_engine_product_multi_price/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Shopinvader Search Engine Product Multi Price",
     "summary": "Add the export of multiple prices for Shopinvader",
-    "version": "16.0.1.1.0",
+    "version": "18.0.1.0.0",
     "category": "e-commerce",
     "license": "AGPL-3",
     "author": "ACSONE SA/NV",
@@ -13,5 +13,5 @@
     "data": ["views/se_backend.xml", "views/se_index.xml"],
     "demo": [],
     "development_status": "Alpha",
-    "installable": False,
+    "installable": True,
 }

--- a/shopinvader_search_engine_product_multi_price/models/product_product.py
+++ b/shopinvader_search_engine_product_multi_price/models/product_product.py
@@ -15,17 +15,11 @@ class ProductProduct(models.Model):
     def _compute_shopinvader_price_by_pricelist(self):
         index_id = self.env.context.get("index_id", False)
         index = self.env["se.index"].browse(index_id)
-        prices = {}
-        if index_id:
-            for pricelist in index._get_pricelists():
-                price_unit_list = self._get_price(pricelist=pricelist)
-                prices[pricelist.id] = price_unit_list
         for product in self:
             price_by_pricelist = {}
             if index_id:
                 for pricelist in index._get_pricelists():
-                    if product.id in prices[pricelist.id]:
-                        price_by_pricelist.update(
-                            {pricelist.id: prices[pricelist.id][product.id]}
-                        )
+                    price_by_pricelist.update(
+                        {pricelist.id: self._get_price(pricelist=pricelist)}
+                    )
             product.shopinvader_price_by_pricelist = price_by_pricelist

--- a/shopinvader_search_engine_product_multi_price/pyproject.toml
+++ b/shopinvader_search_engine_product_multi_price/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/shopinvader_search_engine_product_multi_price/readme/CONTRIBUTORS.md
+++ b/shopinvader_search_engine_product_multi_price/readme/CONTRIBUTORS.md
@@ -1,0 +1,1 @@
+- Quentin Groulard \<quentin.groulard@acsone.eu\>

--- a/shopinvader_search_engine_product_multi_price/readme/CONTRIBUTORS.rst
+++ b/shopinvader_search_engine_product_multi_price/readme/CONTRIBUTORS.rst
@@ -1,1 +1,0 @@
-* Quentin Groulard <quentin.groulard@acsone.eu>

--- a/shopinvader_search_engine_product_multi_price/readme/DESCRIPTION.md
+++ b/shopinvader_search_engine_product_multi_price/readme/DESCRIPTION.md
@@ -1,0 +1,7 @@
+Adds prices to the export of products for Shopinvader. One price is
+exported per pricelist set on the index.
+
+It means that your website needs to know which pricelist to choose.
+Thus, we suggest to use this module in combination with
+`shopinvader_api_customer`, which provides an API to get the customer's
+pricelist.

--- a/shopinvader_search_engine_product_multi_price/readme/DESCRIPTION.rst
+++ b/shopinvader_search_engine_product_multi_price/readme/DESCRIPTION.rst
@@ -1,6 +1,0 @@
-Adds prices to the export of products for Shopinvader.
-One price is exported per pricelist set on the index.
-
-It means that your website needs to know which pricelist to choose.
-Thus, we suggest to use this module in combination with ``shopinvader_api_customer``,
-which provides an API to get the customer's pricelist.

--- a/shopinvader_search_engine_product_multi_price/readme/USAGE.md
+++ b/shopinvader_search_engine_product_multi_price/readme/USAGE.md
@@ -1,0 +1,2 @@
+Set pricelists per index or on the search engine backend to apply
+globally.

--- a/shopinvader_search_engine_product_multi_price/readme/USAGE.rst
+++ b/shopinvader_search_engine_product_multi_price/readme/USAGE.rst
@@ -1,1 +1,0 @@
-Set pricelists per index or on the search engine backend to apply globally.

--- a/shopinvader_search_engine_product_multi_price/static/description/index.html
+++ b/shopinvader_search_engine_product_multi_price/static/description/index.html
@@ -369,12 +369,13 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:46a5934cff521bcf91c45618f0013943a4c15312dc6c4f3d2be10375b9e2b9a6
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Alpha" src="https://img.shields.io/badge/maturity-Alpha-red.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_search_engine_product_multi_price"><img alt="shopinvader/odoo-shopinvader" src="https://img.shields.io/badge/github-shopinvader%2Fodoo--shopinvader-lightgray.png?logo=github" /></a></p>
-<p>Adds prices to the export of products for Shopinvader.
-One price is exported per pricelist set on the index.</p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Alpha" src="https://img.shields.io/badge/maturity-Alpha-red.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/shopinvader/odoo-shopinvader-search-engine/tree/18.0/shopinvader_search_engine_product_multi_price"><img alt="shopinvader/odoo-shopinvader-search-engine" src="https://img.shields.io/badge/github-shopinvader%2Fodoo--shopinvader--search--engine-lightgray.png?logo=github" /></a></p>
+<p>Adds prices to the export of products for Shopinvader. One price is
+exported per pricelist set on the index.</p>
 <p>It means that your website needs to know which pricelist to choose.
-Thus, we suggest to use this module in combination with <tt class="docutils literal">shopinvader_api_customer</tt>,
-which provides an API to get the customer’s pricelist.</p>
+Thus, we suggest to use this module in combination with
+<tt class="docutils literal">shopinvader_api_customer</tt>, which provides an API to get the
+customer’s pricelist.</p>
 <div class="admonition important">
 <p class="first admonition-title">Important</p>
 <p class="last">This is an alpha version, the data model and design can change at any time without warning.
@@ -396,14 +397,15 @@ Only for development or testing purpose, do not use in production.
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-1">Usage</a></h1>
-<p>Set pricelists per index or on the search engine backend to apply globally.</p>
+<p>Set pricelists per index or on the search engine backend to apply
+globally.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
-<p>Bugs are tracked on <a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader/issues">GitHub Issues</a>.
+<p>Bugs are tracked on <a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader-search-engine/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader/issues/new?body=module:%20shopinvader_search_engine_product_multi_price%0Aversion:%2016.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader-search-engine/issues/new?body=module:%20shopinvader_search_engine_product_multi_price%0Aversion:%2018.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
@@ -422,7 +424,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
-<p>This module is part of the <a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_search_engine_product_multi_price">shopinvader/odoo-shopinvader</a> project on GitHub.</p>
+<p>This module is part of the <a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader-search-engine/tree/18.0/shopinvader_search_engine_product_multi_price">shopinvader/odoo-shopinvader-search-engine</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>
 </div>

--- a/shopinvader_search_engine_product_multi_price/tests/test_product_binding.py
+++ b/shopinvader_search_engine_product_multi_price/tests/test_product_binding.py
@@ -5,19 +5,19 @@ from odoo.addons.shopinvader_search_engine.tests.common import TestBindingIndexB
 
 
 class TestProductBinding(TestBindingIndexBase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.index = cls.env["se.index"].create(
+    def setup_records(self, backend=None):
+        rv = super().setup_records(backend=backend)
+        self.index = self.env["se.index"].create(
             {
                 "name": "product",
-                "backend_id": cls.backend.id,
-                "model_id": cls.env.ref("product.model_product_product").id,
+                "backend_id": self.backend.id,
+                "model_id": self.env.ref("product.model_product_product").id,
                 "serializer_type": "shopinvader_product_exports",
             }
         )
-        cls.product = cls.env.ref("product.product_product_4b")
-        cls.product_binding = cls.product._add_to_index(cls.index)
+        self.product = self.env.ref("product.product_product_4b")
+        self.product_binding = self.product._add_to_index(self.index)
+        return rv
 
     def test_binding_prices_no_pricelist(self):
         self.product_binding.recompute_json()
@@ -25,8 +25,8 @@ class TestProductBinding(TestBindingIndexBase):
         self.assertEqual(len(data["price_by_pricelist"]), 0)
 
     def test_binding_price_by_pricelist(self):
-        pricelist_1 = self.env.ref("product.list0")
-        pricelist_2 = self.env.ref("product_get_price_helper.pricelist_1")
+        pricelist_1 = self.env.ref("product_get_price_helper.pricelist_1")
+        pricelist_2 = self.env["product.pricelist"].create({"name": "pricelist 2"})
         self.index.backend_id.pricelist_ids = [(6, 0, (pricelist_1 | pricelist_2).ids)]
         self.product_binding.recompute_json()
         data = self.product_binding.data
@@ -34,18 +34,18 @@ class TestProductBinding(TestBindingIndexBase):
         self.assertEqual(
             data["price_by_pricelist"][str(pricelist_1.id)],
             {
-                "value": 750.0,
+                "value": 600.0,
                 "tax_included": False,
                 "discount": 0.0,
-                "original_value": 750.0,
+                "original_value": 600.0,
             },
         )
         self.assertEqual(
             data["price_by_pricelist"][str(pricelist_2.id)],
             {
-                "value": 600.0,
+                "value": 750.0,
                 "tax_included": False,
                 "discount": 0.0,
-                "original_value": 600.0,
+                "original_value": 750.0,
             },
         )


### PR DESCRIPTION
Standard migration

Depends on: 
  - https://github.com/OCA/search-engine/pull/222
  - https://github.com/OCA/search-engine/pull/224
  - https://github.com/OCA/product-attribute/pull/2130
  - https://github.com/shopinvader/odoo-shopinvader-catalog/pull/2
  - #2

Same remark as #4