### PR TITLE
[18.0] [MIG] shopinvader_search_engine_update_pricelist

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,6 @@ exclude: |
   ^shopinvader_search_engine_product_template_multi_link/|
   ^shopinvader_search_engine_update/|
   ^shopinvader_search_engine_update_image/|
-  ^shopinvader_search_engine_update_pricelist/|
   ^shopinvader_search_engine_update_product_brand/|
   ^shopinvader_search_engine_update_product_brand_image/|
   ^shopinvader_search_engine_update_product_brand_tag/|

--- a/shopinvader_search_engine_update_pricelist/README.rst
+++ b/shopinvader_search_engine_update_pricelist/README.rst
@@ -16,9 +16,9 @@ Shopinvader Search Engine Update Pricelist
 .. |badge2| image:: https://img.shields.io/badge/licence-AGPL--3-blue.png
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
-.. |badge3| image:: https://img.shields.io/badge/github-shopinvader%2Fodoo--shopinvader-lightgray.png?logo=github
-    :target: https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_search_engine_update_pricelist
-    :alt: shopinvader/odoo-shopinvader
+.. |badge3| image:: https://img.shields.io/badge/github-shopinvader%2Fodoo--shopinvader--search--engine-lightgray.png?logo=github
+    :target: https://github.com/shopinvader/odoo-shopinvader-search-engine/tree/18.0/shopinvader_search_engine_update_pricelist
+    :alt: shopinvader/odoo-shopinvader-search-engine
 
 |badge1| |badge2| |badge3|
 
@@ -42,10 +42,10 @@ into the search engine as soon as possible.
 Bug Tracker
 ===========
 
-Bugs are tracked on `GitHub Issues <https://github.com/shopinvader/odoo-shopinvader/issues>`_.
+Bugs are tracked on `GitHub Issues <https://github.com/shopinvader/odoo-shopinvader-search-engine/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/shopinvader/odoo-shopinvader/issues/new?body=module:%20shopinvader_search_engine_update_pricelist%0Aversion:%2016.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/shopinvader/odoo-shopinvader-search-engine/issues/new?body=module:%20shopinvader_search_engine_update_pricelist%0Aversion:%2018.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -60,12 +60,12 @@ Authors
 Contributors
 ------------
 
--  Tri Doan tridm@trobz.com
--  Simone Orsi simone.orsi@camptocamp.com
+- Tri Doan tridm@trobz.com
+- Simone Orsi simone.orsi@camptocamp.com
 
 Maintainers
 -----------
 
-This module is part of the `shopinvader/odoo-shopinvader <https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_search_engine_update_pricelist>`_ project on GitHub.
+This module is part of the `shopinvader/odoo-shopinvader-search-engine <https://github.com/shopinvader/odoo-shopinvader-search-engine/tree/18.0/shopinvader_search_engine_update_pricelist>`_ project on GitHub.
 
 You are welcome to contribute.

--- a/shopinvader_search_engine_update_pricelist/__manifest__.py
+++ b/shopinvader_search_engine_update_pricelist/__manifest__.py
@@ -3,13 +3,14 @@
 
 {
     "name": "Shopinvader Search Engine Update Pricelist",
-    "summary": "Shopinvader: Mark product binding to export on Product Pricelist update",
+    "summary": "Shopinvader: Mark product binding to export on "
+    "Product Pricelist update",
     "author": "Camptocamp, Odoo Community Association (OCA)",
-    "version": "16.0.1.0.0",
+    "version": "18.0.1.0.0",
     "license": "AGPL-3",
     "website": "https://github.com/shopinvader/odoo-shopinvader-search-engine",
     "depends": [
         "shopinvader_search_engine_update",
     ],
-    "installable": False,
+    "installable": True,
 }

--- a/shopinvader_search_engine_update_pricelist/pyproject.toml
+++ b/shopinvader_search_engine_update_pricelist/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/shopinvader_search_engine_update_pricelist/static/description/index.html
+++ b/shopinvader_search_engine_update_pricelist/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -369,7 +369,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:96da39c7e52208bc08613796624aec465adf701f2f9fa0e35cb7a84cabf7b5b3
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_search_engine_update_pricelist"><img alt="shopinvader/odoo-shopinvader" src="https://img.shields.io/badge/github-shopinvader%2Fodoo--shopinvader-lightgray.png?logo=github" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/shopinvader/odoo-shopinvader-search-engine/tree/18.0/shopinvader_search_engine_update_pricelist"><img alt="shopinvader/odoo-shopinvader-search-engine" src="https://img.shields.io/badge/github-shopinvader%2Fodoo--shopinvader--search--engine-lightgray.png?logo=github" /></a></p>
 <p>This module extends the functionality of the
 <tt class="docutils literal">shopinvader_search_engine_update</tt> to mark the information exported to
 the search engine as to be recomputed when the product pricelist data
@@ -395,10 +395,10 @@ into the search engine as soon as possible.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
-<p>Bugs are tracked on <a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader/issues">GitHub Issues</a>.
+<p>Bugs are tracked on <a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader-search-engine/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader/issues/new?body=module:%20shopinvader_search_engine_update_pricelist%0Aversion:%2016.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader-search-engine/issues/new?body=module:%20shopinvader_search_engine_update_pricelist%0Aversion:%2018.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
@@ -418,7 +418,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
-<p>This module is part of the <a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_search_engine_update_pricelist">shopinvader/odoo-shopinvader</a> project on GitHub.</p>
+<p>This module is part of the <a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader-search-engine/tree/18.0/shopinvader_search_engine_update_pricelist">shopinvader/odoo-shopinvader-search-engine</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>
 </div>

--- a/shopinvader_search_engine_update_pricelist/tests/common.py
+++ b/shopinvader_search_engine_update_pricelist/tests/common.py
@@ -1,44 +1,31 @@
 # Copyright 2024 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import Command
 
-from odoo.addons.shopinvader_search_engine.tests.common import (
-    TestBindingIndexBase,
-    TestProductBindingMixin,
-)
+from odoo.addons.shopinvader_search_engine.tests.common import TestProductBindingBase
 
 
-class TestMultiProductMixin(TestProductBindingMixin):
-    @classmethod
-    def setup_records(cls, tst_cls, backend=None):
-        res = super().setup_records(tst_cls, backend=backend)
-        tst_cls.product_2 = tst_cls.env.ref(
+class TestMultiProductBindingBase(TestProductBindingBase):
+    def setup_records(self, backend=None):
+        rv = super().setup_records(backend=backend)
+        self.product_2 = self.env.ref(
             "shopinvader_product.product_product_chair_vortex_blue"
         )
-        tst_cls.product_2_binding = tst_cls.product_2._add_to_index(
-            tst_cls.se_product_index
-        )
+        self.product_2_binding = self.product_2._add_to_index(self.se_product_index)
 
-        tst_cls.pricelist_item = tst_cls.env["product.pricelist.item"].create(
-            {
-                "compute_price": "fixed",
-                "product_id": tst_cls.product.id,
-                "applied_on": "0_product_variant",
-                "fixed_price": 70,
-            }
-        )
-        tst_cls.pricelist = tst_cls.env["product.pricelist"].create(
+        self.pricelist = self.env["product.pricelist"].create(
             {
                 "name": "Test pricelist",
-                "item_ids": [Command.link(tst_cls.pricelist_item.id)],
             }
         )
-        return res
 
-
-class TestMultiProductBindingBase(TestBindingIndexBase, TestMultiProductMixin):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        TestMultiProductMixin.setup_records(cls)
+        self.pricelist_item = self.env["product.pricelist.item"].create(
+            {
+                "compute_price": "fixed",
+                "product_id": self.product.id,
+                "applied_on": "0_product_variant",
+                "fixed_price": 70,
+                "pricelist_id": self.pricelist.id,
+            }
+        )
+        return rv

--- a/shopinvader_search_engine_update_pricelist/tests/test_update.py
+++ b/shopinvader_search_engine_update_pricelist/tests/test_update.py
@@ -7,11 +7,11 @@ from .common import TestMultiProductBindingBase
 
 
 class TestPriceListItemUpdate(TestMultiProductBindingBase, TestCategoryBindingBase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.product_binding.state = "done"
-        cls.product_2_binding.state = "done"
+    def setup_records(self, backend=None):
+        rv = super().setup_records(backend=backend)
+        self.product_binding.state = "done"
+        self.product_2_binding.state = "done"
+        return rv
 
     def test_update_pricelist_item_variant(self):
         self.assertEqual(self.product_binding.state, "done")

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,6 @@
 odoo-test-helper
 vcrpy-unittest
+
+odoo-addon-shopinvader_product @ git+https://github.com/shopinvader/odoo-shopinvader-catalog@refs/pull/2/head#subdirectory=shopinvader_product
+odoo-addon-shopinvader_search_engine @ git+https://github.com/shopinvader/odoo-shopinvader-search-engine@refs/pull/2/head#subdirectory=shopinvader_search_engine
+odoo-addon-shopinvader_search_engine_update @ git+https://github.com/shopinvader/odoo-shopinvader-search-engine@refs/pull/14/head#subdirectory=shopinvader_search_engine_update


### PR DESCRIPTION
Standard migration

Depends on: 
  - https://github.com/shopinvader/odoo-shopinvader-catalog/pull/2
  - #2
  - #14 