### PR TITLE
[18.0] [MIG] shopinvader_search_engine_update_product_brand_image

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,6 @@ exclude: |
   ^shopinvader_search_engine_update_image/|
   ^shopinvader_search_engine_update_pricelist/|
   ^shopinvader_search_engine_update_product_brand/|
-  ^shopinvader_search_engine_update_product_brand_image/|
   ^shopinvader_search_engine_update_product_brand_tag/|
   ^shopinvader_search_engine_update_product_media/|
   ^shopinvader_search_engine_update_product_template_multi_link/|

--- a/shopinvader_search_engine_update_product_brand_image/README.rst
+++ b/shopinvader_search_engine_update_product_brand_image/README.rst
@@ -16,9 +16,9 @@ Shopinvader Search Engine Update Product Brand Image
 .. |badge2| image:: https://img.shields.io/badge/licence-AGPL--3-blue.png
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
-.. |badge3| image:: https://img.shields.io/badge/github-shopinvader%2Fodoo--shopinvader-lightgray.png?logo=github
-    :target: https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_search_engine_update_product_brand_image
-    :alt: shopinvader/odoo-shopinvader
+.. |badge3| image:: https://img.shields.io/badge/github-shopinvader%2Fodoo--shopinvader--search--engine-lightgray.png?logo=github
+    :target: https://github.com/shopinvader/odoo-shopinvader-search-engine/tree/18.0/shopinvader_search_engine_update_product_brand_image
+    :alt: shopinvader/odoo-shopinvader-search-engine
 
 |badge1| |badge2| |badge3|
 
@@ -49,10 +49,10 @@ search engine as soon as possible.
 Bug Tracker
 ===========
 
-Bugs are tracked on `GitHub Issues <https://github.com/shopinvader/odoo-shopinvader/issues>`_.
+Bugs are tracked on `GitHub Issues <https://github.com/shopinvader/odoo-shopinvader-search-engine/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/shopinvader/odoo-shopinvader/issues/new?body=module:%20shopinvader_search_engine_update_product_brand_image%0Aversion:%2016.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/shopinvader/odoo-shopinvader-search-engine/issues/new?body=module:%20shopinvader_search_engine_update_product_brand_image%0Aversion:%2018.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -67,11 +67,11 @@ Authors
 Contributors
 ------------
 
--  Laurent Mignon laurent.mignon@acsone.eu (https://www.acsone.eu)
+- Laurent Mignon laurent.mignon@acsone.eu (https://www.acsone.eu)
 
 Maintainers
 -----------
 
-This module is part of the `shopinvader/odoo-shopinvader <https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_search_engine_update_product_brand_image>`_ project on GitHub.
+This module is part of the `shopinvader/odoo-shopinvader-search-engine <https://github.com/shopinvader/odoo-shopinvader-search-engine/tree/18.0/shopinvader_search_engine_update_product_brand_image>`_ project on GitHub.
 
 You are welcome to contribute.

--- a/shopinvader_search_engine_update_product_brand_image/__manifest__.py
+++ b/shopinvader_search_engine_update_product_brand_image/__manifest__.py
@@ -3,18 +3,18 @@
 
 {
     "name": "Shopinvader Search Engine Update Product Brand Image",
-    "summary": """
-        Mark brand and product bindings to export on product image brand update""",
-    "version": "16.0.1.0.0",
+    "summary": "Mark brand and product bindings to export on "
+    "product image brand update",
+    "version": "18.0.1.0.0",
     "license": "AGPL-3",
     "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
     "website": "https://github.com/shopinvader/odoo-shopinvader-search-engine",
     "depends": [
-        "shopinvader_search_engine_update",
         "shopinvader_search_engine_product_brand_image",
+        "shopinvader_search_engine_update",
+        "shopinvader_search_engine_update_product_brand",
     ],
     "data": [],
-    "demo": [],
     "development_status": "Alpha",
-    "installable": False,
+    "installable": True,
 }

--- a/shopinvader_search_engine_update_product_brand_image/pyproject.toml
+++ b/shopinvader_search_engine_update_product_brand_image/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/shopinvader_search_engine_update_product_brand_image/static/description/index.html
+++ b/shopinvader_search_engine_update_product_brand_image/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -369,7 +369,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:f1cf4b809267c056e7c6793e1df307333bf7ef333c7a7c77e482958a446bed40
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Alpha" src="https://img.shields.io/badge/maturity-Alpha-red.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_search_engine_update_product_brand_image"><img alt="shopinvader/odoo-shopinvader" src="https://img.shields.io/badge/github-shopinvader%2Fodoo--shopinvader-lightgray.png?logo=github" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Alpha" src="https://img.shields.io/badge/maturity-Alpha-red.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/shopinvader/odoo-shopinvader-search-engine/tree/18.0/shopinvader_search_engine_update_product_brand_image"><img alt="shopinvader/odoo-shopinvader-search-engine" src="https://img.shields.io/badge/github-shopinvader%2Fodoo--shopinvader--search--engine-lightgray.png?logo=github" /></a></p>
 <p>This module extends the functionality of the
 <tt class="docutils literal">shopinvader_search_engine_update</tt> and
 <tt class="docutils literal">shopinvader_search_engine_product_brand_image</tt> modules to mark the
@@ -403,10 +403,10 @@ search engine as soon as possible.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
-<p>Bugs are tracked on <a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader/issues">GitHub Issues</a>.
+<p>Bugs are tracked on <a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader-search-engine/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader/issues/new?body=module:%20shopinvader_search_engine_update_product_brand_image%0Aversion:%2016.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader-search-engine/issues/new?body=module:%20shopinvader_search_engine_update_product_brand_image%0Aversion:%2018.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
@@ -425,7 +425,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
-<p>This module is part of the <a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_search_engine_update_product_brand_image">shopinvader/odoo-shopinvader</a> project on GitHub.</p>
+<p>This module is part of the <a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader-search-engine/tree/18.0/shopinvader_search_engine_update_product_brand_image">shopinvader/odoo-shopinvader-search-engine</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>
 </div>

--- a/shopinvader_search_engine_update_product_brand_image/tests/test_update.py
+++ b/shopinvader_search_engine_update_product_brand_image/tests/test_update.py
@@ -2,25 +2,23 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 import base64
 
-from odoo.addons.shopinvader_search_engine.tests.common import TestProductBindingMixin
 from odoo.addons.shopinvader_search_engine_product_brand_image.tests.common import (
     ProductBrandImageCase,
 )
 
 
-class TestUpdate(ProductBrandImageCase, TestProductBindingMixin):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        TestProductBindingMixin.setup_records(cls)
-        cls.product.product_brand_id = cls.brand
-        cls.product_binding.state = "done"
-        cls.brand_binding.state = "done"
-        cls.new_tag = cls.env["image.tag"].create(
+class TestUpdate(ProductBrandImageCase):
+    def setup_records(self, backend=None):
+        rv = super().setup_records(backend=backend)
+        self.product.product_brand_id = self.brand
+        self.product_binding.state = "done"
+        self.brand_binding.state = "done"
+        self.new_tag = self.env["image.tag"].create(
             {
                 "name": "new_tag",
             }
         )
+        return rv
 
     def test_unlink_image(self):
         self.brand.image_ids.unlink()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,21 @@
 odoo-test-helper
 vcrpy-unittest
+
+odoo-addon-fs_image_thumbnail @ git+https://github.com/OCA/storage.git@refs/pull/470/head#subdirectory=fs_image_thumbnail
+odoo-addon-fs_base_multi_image @ git+https://github.com/OCA/storage.git@refs/pull/506/head#subdirectory=fs_base_multi_image
+odoo-addon-fs_product_multi_image @ git+https://github.com/OCA/storage.git@refs/pull/449/head#subdirectory=fs_product_multi_image
+odoo-addon-fs_product_brand_multi_image @ git+https://github.com/OCA/storage.git@refs/pull/505/head#subdirectory=fs_product_brand_multi_image
+
+odoo-addon-search_engine_image_thumbnail @ git+https://github.com/OCA/search-engine.git@refs/pull/228/head#subdirectory=search_engine_image_thumbnail
+
+odoo-addon-shopinvader_base_url @ git+https://github.com/shopinvader/odoo-shopinvader-catalog@refs/pull/1/head#subdirectory=shopinvader_base_url
+odoo-addon-shopinvader_product @ git+https://github.com/shopinvader/odoo-shopinvader-catalog@refs/pull/2/head#subdirectory=shopinvader_product
+odoo-addon-shopinvader_product_seo @ git+https://github.com/shopinvader/odoo-shopinvader-catalog@refs/pull/5/head#subdirectory=shopinvader_product_seo
+odoo-addon-shopinvader_product_brand @ git+https://github.com/shopinvader/odoo-shopinvader-catalog@refs/pull/6/head#subdirectory=shopinvader_product_brand
+
+odoo-addon-shopinvader_search_engine @ git+https://github.com/shopinvader/odoo-shopinvader-search-engine@refs/pull/2/head#subdirectory=shopinvader_search_engine
+odoo-addon-shopinvader_search_engine_product_brand @ git+https://github.com/shopinvader/odoo-shopinvader-search-engine@refs/pull/6/head#subdirectory=shopinvader_search_engine_product_brand
+odoo-addon-shopinvader_search_engine_image @ git+https://github.com/shopinvader/odoo-shopinvader-search-engine@refs/pull/8/head#subdirectory=shopinvader_search_engine_image
+odoo-addon-shopinvader_search_engine_product_brand_image @ git+https://github.com/shopinvader/odoo-shopinvader-search-engine@refs/pull/9/head#subdirectory=shopinvader_search_engine_product_brand_image
+odoo-addon-shopinvader_search_engine_update @ git+https://github.com/shopinvader/odoo-shopinvader-search-engine@refs/pull/14/head#subdirectory=shopinvader_search_engine_update
+odoo-addon-shopinvader_search_engine_update_product_brand @ git+https://github.com/shopinvader/odoo-shopinvader-search-engine@refs/pull/17/head#subdirectory=shopinvader_search_engine_update_product_brand


### PR DESCRIPTION
Standard migration

Depends on: 
  - https://github.com/OCA/storage/pull/470
  - https://github.com/OCA/storage/pull/506
  - https://github.com/OCA/storage/pull/449
  - https://github.com/OCA/storage/pull/505
  - https://github.com/OCA/search-engine/pull/228
  - ~~https://github.com/shopinvader/odoo-shopinvader-catalog/pull/1~~
  - https://github.com/OCA/server-tools/pull/3591
  - https://github.com/shopinvader/odoo-shopinvader-catalog/pull/2
  - https://github.com/shopinvader/odoo-shopinvader-catalog/pull/5
  - ~~https://github.com/shopinvader/odoo-shopinvader-catalog/pull/6~~
  - https://github.com/shopinvader/odoo-shopinvader-catalog/pull/14
  - #2
  - #6 
  - #8 
  - #9
  - #14 
  - #17