### PR TITLE
[18.0] [MIG] shopinvader_search_engine_update_product_brand_tag

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,6 @@ exclude: |
   ^shopinvader_search_engine_update_pricelist/|
   ^shopinvader_search_engine_update_product_brand/|
   ^shopinvader_search_engine_update_product_brand_image/|
-  ^shopinvader_search_engine_update_product_brand_tag/|
   ^shopinvader_search_engine_update_product_media/|
   ^shopinvader_search_engine_update_product_template_multi_link/|
   # END NOT INSTALLABLE ADDONS

--- a/shopinvader_search_engine_update_product_brand_tag/README.rst
+++ b/shopinvader_search_engine_update_product_brand_tag/README.rst
@@ -16,9 +16,9 @@ Shopinvader Seach Engine Product Brand Tag
 .. |badge2| image:: https://img.shields.io/badge/licence-AGPL--3-blue.png
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
-.. |badge3| image:: https://img.shields.io/badge/github-shopinvader%2Fodoo--shopinvader-lightgray.png?logo=github
-    :target: https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_search_engine_update_product_brand_tag
-    :alt: shopinvader/odoo-shopinvader
+.. |badge3| image:: https://img.shields.io/badge/github-shopinvader%2Fodoo--shopinvader--search--engine-lightgray.png?logo=github
+    :target: https://github.com/shopinvader/odoo-shopinvader-search-engine/tree/18.0/shopinvader_search_engine_update_product_brand_tag
+    :alt: shopinvader/odoo-shopinvader-search-engine
 
 |badge1| |badge2| |badge3|
 
@@ -49,10 +49,10 @@ search engine as soon as possible.
 Bug Tracker
 ===========
 
-Bugs are tracked on `GitHub Issues <https://github.com/shopinvader/odoo-shopinvader/issues>`_.
+Bugs are tracked on `GitHub Issues <https://github.com/shopinvader/odoo-shopinvader-search-engine/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/shopinvader/odoo-shopinvader/issues/new?body=module:%20shopinvader_search_engine_update_product_brand_tag%0Aversion:%2016.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/shopinvader/odoo-shopinvader-search-engine/issues/new?body=module:%20shopinvader_search_engine_update_product_brand_tag%0Aversion:%2018.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -67,11 +67,11 @@ Authors
 Contributors
 ------------
 
--  Laurent Mignon laurent.mignon@acsone.eu (https://www.acsone.eu)
+- Laurent Mignon laurent.mignon@acsone.eu (https://www.acsone.eu)
 
 Maintainers
 -----------
 
-This module is part of the `shopinvader/odoo-shopinvader <https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_search_engine_update_product_brand_tag>`_ project on GitHub.
+This module is part of the `shopinvader/odoo-shopinvader-search-engine <https://github.com/shopinvader/odoo-shopinvader-search-engine/tree/18.0/shopinvader_search_engine_update_product_brand_tag>`_ project on GitHub.
 
 You are welcome to contribute.

--- a/shopinvader_search_engine_update_product_brand_tag/__manifest__.py
+++ b/shopinvader_search_engine_update_product_brand_tag/__manifest__.py
@@ -3,9 +3,8 @@
 
 {
     "name": "Shopinvader Seach Engine Product Brand Tag",
-    "summary": """
-        Mark brand and product bindings to export on product image tag update""",
-    "version": "16.0.1.0.0",
+    "summary": "Mark brand and product bindings to export on product image tag update",
+    "version": "18.0.1.0.0",
     "license": "AGPL-3",
     "author": "ACSONE SA/NV",
     "website": "https://github.com/shopinvader/odoo-shopinvader-search-engine",
@@ -14,7 +13,6 @@
         "shopinvader_product_brand_tag",
     ],
     "data": [],
-    "demo": [],
     "development_status": "Alpha",
-    "installable": False,
+    "installable": True,
 }

--- a/shopinvader_search_engine_update_product_brand_tag/pyproject.toml
+++ b/shopinvader_search_engine_update_product_brand_tag/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/shopinvader_search_engine_update_product_brand_tag/static/description/index.html
+++ b/shopinvader_search_engine_update_product_brand_tag/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -369,7 +369,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:d8349c0d95cacf5dda6e4311057743e795bc0adc27257879ec4e9878196bd6a2
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Alpha" src="https://img.shields.io/badge/maturity-Alpha-red.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_search_engine_update_product_brand_tag"><img alt="shopinvader/odoo-shopinvader" src="https://img.shields.io/badge/github-shopinvader%2Fodoo--shopinvader-lightgray.png?logo=github" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Alpha" src="https://img.shields.io/badge/maturity-Alpha-red.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/shopinvader/odoo-shopinvader-search-engine/tree/18.0/shopinvader_search_engine_update_product_brand_tag"><img alt="shopinvader/odoo-shopinvader-search-engine" src="https://img.shields.io/badge/github-shopinvader%2Fodoo--shopinvader--search--engine-lightgray.png?logo=github" /></a></p>
 <p>This module extends the functionality of the
 <tt class="docutils literal">shopinvader_product_brand_tag</tt> and
 <tt class="docutils literal">shopinvader_search_engine_update_product_brand</tt> modules to mark the
@@ -403,10 +403,10 @@ search engine as soon as possible.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h1>
-<p>Bugs are tracked on <a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader/issues">GitHub Issues</a>.
+<p>Bugs are tracked on <a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader-search-engine/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader/issues/new?body=module:%20shopinvader_search_engine_update_product_brand_tag%0Aversion:%2016.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader-search-engine/issues/new?body=module:%20shopinvader_search_engine_update_product_brand_tag%0Aversion:%2018.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
@@ -425,7 +425,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </div>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
-<p>This module is part of the <a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader/tree/16.0/shopinvader_search_engine_update_product_brand_tag">shopinvader/odoo-shopinvader</a> project on GitHub.</p>
+<p>This module is part of the <a class="reference external" href="https://github.com/shopinvader/odoo-shopinvader-search-engine/tree/18.0/shopinvader_search_engine_update_product_brand_tag">shopinvader/odoo-shopinvader-search-engine</a> project on GitHub.</p>
 <p>You are welcome to contribute.</p>
 </div>
 </div>

--- a/shopinvader_search_engine_update_product_brand_tag/tests/test_update.py
+++ b/shopinvader_search_engine_update_product_brand_tag/tests/test_update.py
@@ -7,22 +7,22 @@ from odoo.addons.shopinvader_search_engine_update_product_brand.tests.common imp
 
 
 class TestUpdate(TestProductBrandUpdateBase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.tag = cls.env["product.brand.tag"].create(
+    def setup_records(self, backend=None):
+        rv = super().setup_records(backend=backend)
+        self.tag = self.env["product.brand.tag"].create(
             {
                 "name": "tag",
             }
         )
-        cls.new_tag = cls.env["product.brand.tag"].create(
+        self.new_tag = self.env["product.brand.tag"].create(
             {
                 "name": "new_tag",
             }
         )
-        cls.brand.tag_ids = cls.tag
-        cls.brand_binding.state = "done"
-        cls.product_binding.state = "done"
+        self.brand.tag_ids = self.tag
+        self.brand_binding.state = "done"
+        self.product_binding.state = "done"
+        return rv
 
     def test_unlink_tag(self):
         self.brand.tag_ids.unlink()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,13 @@
 odoo-test-helper
 vcrpy-unittest
+
+odoo-addon-shopinvader_base_url @ git+https://github.com/shopinvader/odoo-shopinvader-catalog@refs/pull/1/head#subdirectory=shopinvader_base_url
+odoo-addon-shopinvader_product @ git+https://github.com/shopinvader/odoo-shopinvader-catalog@refs/pull/2/head#subdirectory=shopinvader_product
+odoo-addon-shopinvader_product_seo @ git+https://github.com/shopinvader/odoo-shopinvader-catalog@refs/pull/5/head#subdirectory=shopinvader_product_seo
+odoo-addon-shopinvader_product_brand @ git+https://github.com/shopinvader/odoo-shopinvader-catalog@refs/pull/6/head#subdirectory=shopinvader_product_brand
+odoo-addon-shopinvader_product_brand_tag @ git+https://github.com/shopinvader/odoo-shopinvader-catalog@refs/pull/7/head#subdirectory=shopinvader_product_brand_tag
+
+odoo-addon-shopinvader_search_engine @ git+https://github.com/shopinvader/odoo-shopinvader-search-engine@refs/pull/2/head#subdirectory=shopinvader_search_engine
+odoo-addon-shopinvader_search_engine_product_brand @ git+https://github.com/shopinvader/odoo-shopinvader-search-engine@refs/pull/6/head#subdirectory=shopinvader_search_engine_product_brand
+odoo-addon-shopinvader_search_engine_update @ git+https://github.com/shopinvader/odoo-shopinvader-search-engine@refs/pull/14/head#subdirectory=shopinvader_search_engine_update
+odoo-addon-shopinvader_search_engine_update_product_brand @ git+https://github.com/shopinvader/odoo-shopinvader-search-engine@refs/pull/17/head#subdirectory=shopinvader_search_engine_update_product_brand


### PR DESCRIPTION
Standard migration

Depends on: 
  - https://github.com/shopinvader/odoo-shopinvader-catalog/pull/1
  - https://github.com/shopinvader/odoo-shopinvader-catalog/pull/2
  - https://github.com/shopinvader/odoo-shopinvader-catalog/pull/5
  - https://github.com/shopinvader/odoo-shopinvader-catalog/pull/6
  - https://github.com/shopinvader/odoo-shopinvader-catalog/pull/7
  - #2
  - #6
  - #14
  - #17